### PR TITLE
1 Remove auto margin top from `cc-home-icon-cta__text`

### DIFF
--- a/resources/styles/blocks/_home-page-icon-cta.scss
+++ b/resources/styles/blocks/_home-page-icon-cta.scss
@@ -39,10 +39,4 @@
     margin-top: 0;
     max-width: 265px;
   }
-
-  &__text {
-    @media (min-width: 768px) {
-      margin-top: auto;
-    }
-  }
 }

--- a/resources/styles/blocks/_icon-cta.scss
+++ b/resources/styles/blocks/_icon-cta.scss
@@ -47,18 +47,4 @@
   &__text {
     margin-bottom: max(min(calc((32 / 1800) * 100vw), 32px), 20px);
   }
-
-  &__track {
-  }
-}
-
-.splide {
-  &__list {
-  }
-
-  &__slide {
-  }
-
-  &__track {
-  }
 }


### PR DESCRIPTION
Removes the `margin-top: auto` from the homepage icon CTA text.

closes #1