### PR TITLE
11 blog page not working

### DIFF
--- a/resources/views/partials/content.blade.php
+++ b/resources/views/partials/content.blade.php
@@ -3,7 +3,7 @@
   <div class="entry-wrap">
     <div class="entry-image">
       <a href="{{ get_permalink() }}">
-      {!! get_the_post_thumbnail( $post_id, 'blog-index' ) !!}
+      {!! get_the_post_thumbnail( $post->ID, 'blog-index' ) !!}
       </a>
     </div>
 


### PR DESCRIPTION
Replace `$post_id` with `$post->ID` when retrieving images on the index

closes #11
