### PR TITLE
24 Team Member's Page

### DIFF
--- a/resources/styles/blocks/_team-directory.scss
+++ b/resources/styles/blocks/_team-directory.scss
@@ -77,7 +77,7 @@
   }
 
   &__team-member {
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     display: flex;
   }


### PR DESCRIPTION
change alignment of individual team member items from `center` to
`flex-start` to align images/names/titles

✅ Closes: #24
