### PR TITLE
fix: social icon size

### DIFF
--- a/resources/styles/partials/_widgets.scss
+++ b/resources/styles/partials/_widgets.scss
@@ -23,4 +23,8 @@
     display: inline-block;
     padding: 0 5px;
   }
+
+  &__icon {
+    @include font-size(25px);
+  }
 }


### PR DESCRIPTION
Increase size of social icons to `25px`